### PR TITLE
Added mac support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,32 @@ You may also be able to use the version of `hdiapi` from your distribution's pac
 sudo apt install libusb-1.0-0-dev libhidapi-dev libhidapi-libusb0
 ```
 
+### Building under macOS
+
+Currently the hidapi library does not support interface numbers for devices in macOS. There is an
+[open pull request](https://github.com/signal11/hidapi/pull/380) to add interface number support for HID devices only.
+
+Follow the instructions below to compile hidapi with interface number support:
+
+```
+git clone https://github.com/signal11/hidapi.git
+cd hidapi
+git remote add dylanmckay https://github.com/dylanmckay/hidapi.git
+git fetch dylanmckay
+git checkout mac-hid-interface-support
+./bootstap
+./configure
+make
+sudo make install
+```
+
+After compileing hidapi, you may build zeal60 using the Makefile found in the `zeal60/` directory:
+
+```
+cd zeal60
+make
+```
+
 #### Using Makefile
 To compile the Linux version you can use the supplied Makefile found in the `zeal60/` directrory:
 

--- a/zeal60/Makefile
+++ b/zeal60/Makefile
@@ -1,5 +1,14 @@
+OSNAME:=$(shell uname -s)
+
+CPPFLAGS=-I/usr/local/lib -Wno-write-strings
+ifeq ($(OSNAME),Darwin)
+	CPPFLAGS += -lhidapi
+else
+	CPPFLAGS += -I/usr/local/include/hidapi -lhidapi-libusb
+endif
+
 zeal60: zeal60.cpp keycode.cpp keycode.h config.h
-	g++ -I/usr/local/include/hidapi -L/usr/local/lib -Wno-write-strings zeal60.cpp keycode.cpp -lhidapi-libusb -o zeal60
+	g++ $(CPPFLAGS) zeal60.cpp keycode.cpp -o zeal60
 
 clean:
 	$(RM) zeal60

--- a/zeal60/zeal60.cpp
+++ b/zeal60/zeal60.cpp
@@ -266,7 +266,7 @@ bool system_get_state( hid_device *device, msg_system_state *msg )
 hid_device *
 hid_open_least_uptime( unsigned short vendor_id, unsigned short product_id, unsigned short interface_number )
 {
-	std::vector<std::string> devicePaths = hid_get_device_paths(vendor_id, product_id, interface_number );
+	std::vector<std::string> devicePaths = hid_get_device_paths( vendor_id, product_id, interface_number );
 
 	// early abort
 	if ( devicePaths.size() == 0 )


### PR DESCRIPTION
First off, thanks for all of your work on this project and QMK. 

This PR is to add mac support. Currently hidapi always returns `-1` for the interface number in mac. There is a [relatively new PR](https://github.com/signal11/hidapi/pull/380) that adds interface number support for HID devices for macs, but it has not been merged yet.

I added instructions on building hidapi from the current open PR to the readme, but I understand if you do not want to merge this until the PR is merged.