### PR TITLE
Fixing LDFLAGS in the Makefile so this still compiles under Linux.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 *.exe
 zeal60/zeal60
 zeal60/*.o
+
+# Ignore vim swap files
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+

--- a/linux/10-zeal60.rules
+++ b/linux/10-zeal60.rules
@@ -1,1 +1,3 @@
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="6060", ATTRS{idVendor}=="feed", GROUP="zeal60"
+SUBSYSTEMS=="usb", ATTRS{idProduct}=="6065", ATTRS{idVendor}=="feed", GROUP="zeal60"
+

--- a/readme.md
+++ b/readme.md
@@ -93,3 +93,12 @@ The provided udev rules file gives write access to the usb device for everyone i
 
 Make sure that you've put the `zeal60` binary you compiled in a place the script can find it (such as adding it to your 'PATH' environment variable).
 
+Also, make sure you have installed udev rules correctly for the Zeal keyboards:
+
+```
+sudo cp ./linux/10-zeal60.rules /etc/udev/rules.d/
+
+# Then reload the rules:
+sudo udevadm control --reload-rules && udevadm trigger
+```
+

--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,16 @@ g++ -I/usr/local/include/hidapi -L/usr/local/lib -Wno-write-strings zeal60.cpp k
 
 #### Udev rules
 
-After compiling the Zeal60 command line tool, You need to either run it as root or place the provided udev rule file in `/etc/udev/rules.d/` 
+After compiling the Zeal60 command line tool, You need to either run it as root or place the provided udev rule file in `/etc/udev/rules.d/`. After placing the file there, you either need to reboot (if using the zeal60 group), or reload the rules.
+
+The process is something like this:
+
+```
+sudo cp ./linux/10-zeal60.rules /etc/udev/rules.d/
+
+# Reload the rules:
+sudo udevadm control --reload-rules && udevadm trigger
+```
 
 The provided udev rules file gives write access to the usb device for everyone in the zeal60 group. You should either change this to another group, or make this group and add yourself to it ( `groupadd zeal60; gpasswd -a user zeal60` ).
 
@@ -93,12 +102,6 @@ The provided udev rules file gives write access to the usb device for everyone i
 
 Make sure that you've put the `zeal60` binary you compiled in a place the script can find it (such as adding it to your 'PATH' environment variable).
 
-Also, make sure you have installed udev rules correctly for the Zeal keyboards:
+Also, make sure you have installed udev rules correctly for the Zeal keyboards!
 
-```
-sudo cp ./linux/10-zeal60.rules /etc/udev/rules.d/
-
-# Then reload the rules:
-sudo udevadm control --reload-rules && udevadm trigger
-```
 

--- a/zeal60/Makefile
+++ b/zeal60/Makefile
@@ -1,17 +1,22 @@
 OSNAME:=$(shell uname -s)
 
 CPPFLAGS=-I/usr/local/lib -Wno-write-strings
+
+# Order of LDFLAGS matters! Remember, linking happens after compiling.
+LDFLAGS=
+
 ifeq ($(OSNAME),Darwin)
 	CPPFLAGS += -lhidapi
 else
-	CPPFLAGS += -I/usr/local/include/hidapi -lhidapi-libusb
+	CPPFLAGS += -I/usr/local/include/hidapi
+	LDFLAGS += -lhidapi-libusb
 endif
 
 zeal60: zeal60.cpp keycode.cpp keycode.h config.h
-	g++ $(CPPFLAGS) zeal60.cpp keycode.cpp -o zeal60
+	g++ $(CPPFLAGS) zeal60.cpp keycode.cpp -o zeal60 $(LDFLAGS)
 
 zeal65: zeal60.cpp keycode.cpp keycode.h config.h
-	g++ $(CPPFLAGS) -DZEAL65 zeal60.cpp keycode.cpp -o zeal65
+	g++ $(CPPFLAGS) -DZEAL65 zeal60.cpp keycode.cpp -o zeal65 $(LDFLAGS)
 
 clean:
 	$(RM) zeal60 zeal65


### PR DESCRIPTION
gcc cares about how you tell it to use libraries during the linking step. I'm not sure how this works on other OS's but it doesn't compile unless the order is right.

This is why you often see a CPPFLAGS and a LDFLAGS variable in Makefiles. Ordering!

I also added rules to gitignore to ignore vim swap files... Because, in general, ignoring editor configs and metadata is a good idea.

Thanks!